### PR TITLE
Fix for high-speed mode with a small number of timesteps

### DIFF
--- a/include/trackjoint/error_codes.h
+++ b/include/trackjoint/error_codes.h
@@ -38,5 +38,6 @@ const std::unordered_map<uint, std::string> kErrorCodeMap(
       { kLimitNotPositive, "Vel/accel/jerk limits should be greater than zero" },
       { kGoalPositionMismatch, "Mismatch between the final position and the goal position" },
       { kFailureToGenerateSingleWaypoint, "Failed to generate even a single new waypoint" },
-      { kLessThanTenTimestepsForHighSpeedMode, "In high-speed mode, desired duration should be at least 10 timesteps"} });
+      { kLessThanTenTimestepsForHighSpeedMode, "In high-speed mode, desired duration should be at least 10 "
+                                               "timesteps" } });
 }  // end namespace trackjoint

--- a/include/trackjoint/error_codes.h
+++ b/include/trackjoint/error_codes.h
@@ -23,7 +23,8 @@ enum ErrorCodeEnum
   kMaxDurationLessThanDesiredDuration = 5,
   kLimitNotPositive = 6,
   kGoalPositionMismatch = 7,
-  kFailureToGenerateSingleWaypoint = 8
+  kFailureToGenerateSingleWaypoint = 8,
+  kLessThanTenTimestepsForHighSpeedMode = 9
 };
 
 const std::unordered_map<uint, std::string> kErrorCodeMap(
@@ -36,5 +37,6 @@ const std::unordered_map<uint, std::string> kErrorCodeMap(
       { kMaxDurationLessThanDesiredDuration, "max_duration should not be less than desired_duration" },
       { kLimitNotPositive, "Vel/accel/jerk limits should be greater than zero" },
       { kGoalPositionMismatch, "Mismatch between the final position and the goal position" },
-      { kFailureToGenerateSingleWaypoint, "Failed to generate even a single new waypoint" } });
+      { kFailureToGenerateSingleWaypoint, "Failed to generate even a single new waypoint" },
+      { kLessThanTenTimestepsForHighSpeedMode, "In high-speed mode, desired duration should be at least 10 timesteps"} });
 }  // end namespace trackjoint

--- a/include/trackjoint/trajectory_generator.h
+++ b/include/trackjoint/trajectory_generator.h
@@ -63,10 +63,6 @@ private:
   /** \brief Synchronize all trajectories with the one of longest duration. */
   ErrorCodeEnum SynchronizeTrajComponents(std::vector<JointTrajectory>* output_trajectories);
 
-  /** \brief Set the output state equal to the current state. Used if an error
-   * is encountered. */
-  void SetFinalStateToCurrentState();
-
   const uint kNumDof;
   const double kDesiredTimestep;
   const bool kUseHighSpeedMode;

--- a/include/trackjoint/trajectory_generator.h
+++ b/include/trackjoint/trajectory_generator.h
@@ -74,7 +74,7 @@ private:
   double desired_duration_, max_duration_;
   // TODO(andyz): set this back to a small number when done testing
   const size_t kMaxNumWaypoints = 10000;  // A relatively small number, to run fast
-  const size_t kMinNumWaypoints = 49;     // Upsample for better accuracy if fewer than this many waypoints
+  const size_t kMinNumWaypoints = 10;     // Upsample for better accuracy if fewer than this many waypoints
   std::vector<trackjoint::SingleJointGenerator> single_joint_generators_;
   size_t upsampled_num_waypoints_;
   double upsampled_timestep_;

--- a/src/streaming_example.cpp
+++ b/src/streaming_example.cpp
@@ -30,6 +30,8 @@ int main(int argc, char** argv)
   constexpr double kFinalPositionTolerance = 1e-4;
   constexpr double kFinalVelocityTolerance = 1e-1;
   constexpr double kFinalAccelerationTolerance = 1e-1;
+  // For high-speed mode, it is important to keep the desired duration >=10 timesteps.
+  // Otherwise, an error will be thrown.
   constexpr double kMinDesiredDuration = 10 * kTimestep;
   // Between iterations, move ahead this many waypoints along the trajectory.
   constexpr std::size_t kNextWaypoint = 1;
@@ -49,11 +51,21 @@ int main(int argc, char** argv)
   // But, don't ask for a duration that is shorter than one timestep
   desired_duration = std::max(desired_duration, kMinDesiredDuration);
 
-  // Generate initial trajectory
+  // Create object for trajectory generation
   std::vector<trackjoint::JointTrajectory> output_trajectories(kNumDof);
   trackjoint::TrajectoryGenerator traj_gen(kNumDof, kTimestep, desired_duration, kMaxDuration, start_state,
                                            goal_joint_states, limits, kWaypointPositionTolerance, kUseHighSpeedMode);
-  trackjoint::ErrorCodeEnum error_code = traj_gen.GenerateTrajectories(&output_trajectories);
+
+  // An example of optional input validation
+  trackjoint::ErrorCodeEnum error_code = traj_gen.InputChecking(start_state, goal_joint_states, limits, kTimestep);
+  if (error_code)
+  {
+    std::cout << "Error code: " << trackjoint::kErrorCodeMap.at(error_code) << std::endl;
+    return -1;
+  }
+
+  // Generate the initial trajectory
+  error_code = traj_gen.GenerateTrajectories(&output_trajectories);
   if (error_code != trackjoint::ErrorCodeEnum::kNoError)
   {
     std::cout << "Error code: " << trackjoint::kErrorCodeMap.at(error_code) << std::endl;

--- a/src/streaming_example.cpp
+++ b/src/streaming_example.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
   constexpr double kFinalPositionTolerance = 1e-4;
   constexpr double kFinalVelocityTolerance = 1e-1;
   constexpr double kFinalAccelerationTolerance = 1e-1;
-  constexpr double kMinDesiredDuration = kTimestep;
+  constexpr double kMinDesiredDuration = 10 * kTimestep;
   // Between iterations, move ahead this many waypoints along the trajectory.
   constexpr std::size_t kNextWaypoint = 1;
 

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -30,13 +30,18 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
   // Upsample if num. waypoints would be short. Helps with accuracy
   UpSample();
 
+  // If we needed to perform an UpSample pass, it means the number of waypoints is already small.
+  // Do not use high speed mode.
+  if (upsample_rounds_ > 0)
+    use_high_speed_mode = false;
+
   // Initialize a trajectory generator for each joint
   for (size_t joint = 0; joint < kNumDof; ++joint)
   {
     single_joint_generators_.push_back(SingleJointGenerator(upsampled_timestep_, desired_duration_, max_duration_,
                                                             current_joint_states[joint], goal_joint_states[joint],
                                                             limits[joint], upsampled_num_waypoints_, kMinNumWaypoints,
-                                                            kMaxNumWaypoints, position_tolerance, kUseHighSpeedMode));
+                                                            kMaxNumWaypoints, position_tolerance, use_high_speed_mode));
   }
 }
 

--- a/test/trajectory_generation_test.cpp
+++ b/test/trajectory_generation_test.cpp
@@ -827,8 +827,8 @@ TEST_F(TrajectoryGenerationTest, HighSpeedTooFewTimesteps)
 
   trackjoint::TrajectoryGenerator traj_gen(num_dof_, timestep_, desired_duration_, max_duration_, current_joint_states_,
                                            goal_joint_states_, limits_, position_tolerance_, use_high_speed_mode_);
-  EXPECT_EQ(ErrorCodeEnum::kLessThanTenTimestepsForHighSpeedMode, traj_gen.InputChecking(current_joint_states_,
-    goal_joint_states_, limits_, timestep_));
+  EXPECT_EQ(ErrorCodeEnum::kLessThanTenTimestepsForHighSpeedMode,
+            traj_gen.InputChecking(current_joint_states_, goal_joint_states_, limits_, timestep_));
 }
 }  // namespace trackjoint
 

--- a/test/trajectory_generation_test.cpp
+++ b/test/trajectory_generation_test.cpp
@@ -75,6 +75,26 @@ protected:
   bool use_high_speed_mode_ = false;
 };  // class TrajectoryGenerationTest
 
+TEST_F(TrajectoryGenerationTest, EasyDefaultTrajectory)
+{
+  // Use the class defaults. This trajectory is easy, does not require limit
+  // compensation or trajectory extension
+
+  trackjoint::TrajectoryGenerator traj_gen(num_dof_, timestep_, desired_duration_, max_duration_, current_joint_states_,
+                                           goal_joint_states_, limits_, position_tolerance_, use_high_speed_mode_);
+  std::vector<trackjoint::JointTrajectory> output_trajectories(num_dof_);
+  EXPECT_EQ(ErrorCodeEnum::kNoError, traj_gen.GenerateTrajectories(&output_trajectories));
+
+  // Position error
+  const double kPositionTolerance = 1e-4;
+  const double kPositionError = trackjoint::CalculatePositionAccuracy(goal_joint_states_, output_trajectories);
+  EXPECT_LT(kPositionError, kPositionTolerance);
+  // Duration
+  uint num_waypoint_tolerance = 1;
+  uint expected_num_waypoints = 1 + desired_duration_ / timestep_;
+  EXPECT_NEAR(uint(output_trajectories[0].positions.size()), expected_num_waypoints, num_waypoint_tolerance);
+}
+
 TEST_F(TrajectoryGenerationTest, OneTimestepDuration)
 {
   // Request a duration of one timestep
@@ -516,26 +536,6 @@ TEST_F(TrajectoryGenerationTest, SuddenChangeOfDirection)
   EXPECT_NEAR(output_trajectories[0].elapsed_times(vector_length), kDesiredDuration, kDurationTolerance);
 }
 
-TEST_F(TrajectoryGenerationTest, EasyDefaultTrajectory)
-{
-  // Use the class defaults. This trajectory is easy, does not require limit
-  // compensation or trajectory extension
-
-  trackjoint::TrajectoryGenerator traj_gen(num_dof_, timestep_, desired_duration_, max_duration_, current_joint_states_,
-                                           goal_joint_states_, limits_, position_tolerance_, use_high_speed_mode_);
-  std::vector<trackjoint::JointTrajectory> output_trajectories(num_dof_);
-  EXPECT_EQ(ErrorCodeEnum::kNoError, traj_gen.GenerateTrajectories(&output_trajectories));
-
-  // Position error
-  const double kPositionTolerance = 1e-4;
-  const double kPositionError = trackjoint::CalculatePositionAccuracy(goal_joint_states_, output_trajectories);
-  EXPECT_LT(kPositionError, kPositionTolerance);
-  // Duration
-  uint num_waypoint_tolerance = 1;
-  uint expected_num_waypoints = 1 + desired_duration_ / timestep_;
-  EXPECT_NEAR(uint(output_trajectories[0].positions.size()), expected_num_waypoints, num_waypoint_tolerance);
-}
-
 TEST_F(TrajectoryGenerationTest, LimitCompensation)
 {
   // These test parameters require limit compensation
@@ -756,7 +756,7 @@ TEST_F(TrajectoryGenerationTest, CustomerStreaming)
   constexpr double kFinalPositionTolerance = 1e-5;
   constexpr double kFinalVelocityTolerance = 1e-3;
   constexpr double kFinalAccelerationTolerance = 1e-2;
-  constexpr double kMinDesiredDuration = kTimestep;
+  constexpr double kMinDesiredDuration = 10 * kTimestep;
   // Between iterations, skip this many waypoints.
   // Take kNextWaypoint from the previous trajectory to start the new trajectory.
   // Minimum is 1.
@@ -816,6 +816,19 @@ TEST_F(TrajectoryGenerationTest, CustomerStreaming)
   }
 
   // If the test gets here, it passed.
+}
+
+TEST_F(TrajectoryGenerationTest, HighSpeedTooFewTimesteps)
+{
+  // An error should be thrown if high-speed mode is enabled with a desired duration < kMinNumTimesteps
+
+  use_high_speed_mode_ = true;
+  desired_duration_ = 9 * timestep_;
+
+  trackjoint::TrajectoryGenerator traj_gen(num_dof_, timestep_, desired_duration_, max_duration_, current_joint_states_,
+                                           goal_joint_states_, limits_, position_tolerance_, use_high_speed_mode_);
+  EXPECT_EQ(ErrorCodeEnum::kLessThanTenTimestepsForHighSpeedMode, traj_gen.InputChecking(current_joint_states_,
+    goal_joint_states_, limits_, timestep_));
 }
 }  // namespace trackjoint
 


### PR DESCRIPTION
I noticed while running the streaming demo that the high-speed mode PR (#37) had some timestep issues toward the end of the trajectory. The positions/vels/accels looked good but the delta-t's were wrong. The cause was timestep upsampling and downsampling that expected a certain number of waypoints.

As a fix, this PR requires the user-requested duration to be >=kMinNumTimesteps when high-speed mode is used. That prevents upsampling and downsampling.

Here's a video which shows the streaming example finishing quickly. The timestep is exactly what it should be (0.001) and the position smoothly transitions from 0.9 to -0.9, like it should.

The PR also:

- adds an error code for this
- adds a unit test for the error code
- deletes an unused function (SetFinalStateToCurrentState())
- reorders the unit tests, putting the easy default test at the top of the file

![fast_streaming](https://user-images.githubusercontent.com/11284393/76367385-def27880-62fa-11ea-938b-0cefb9c5bdef.gif)
