### PR TITLE
Implement "Flatten the Curve" interpolation, to reduce overshoot

### DIFF
--- a/src/single_joint_generator.cpp
+++ b/src/single_joint_generator.cpp
@@ -149,27 +149,27 @@ inline Eigen::VectorXd SingleJointGenerator::interpolate(Eigen::VectorXd& times)
 
       // Segment A-B
       // Assume the initial acceleration is maintained for one more timestep
-      double v_A = current_joint_state_.velocity;
-      double a_A = current_joint_state_.acceleration;
-      double x_B = current_joint_state_.position + v_A * delta_t + 0.5 * a_A * delta_t * delta_t;
+      double v_a = current_joint_state_.velocity;
+      double a_a = current_joint_state_.acceleration;
+      double x_b = current_joint_state_.position + v_a * delta_t + 0.5 * a_a * delta_t * delta_t;
 
       // Solving for this segment next may seem out of order, but it's easy to do next since the goal state is known
       // Segment C-D
-      double v_C = goal_joint_state_.velocity;
-      double a_C = goal_joint_state_.acceleration;
-      double x_C = goal_joint_state_.position - v_C * delta_t - 0.5 * a_C * delta_t * delta_t;
-      double t_C = desired_duration_ - 2 * delta_t;
+      double v_c = goal_joint_state_.velocity;
+      double a_c = goal_joint_state_.acceleration;
+      double x_c = goal_joint_state_.position - v_c * delta_t - 0.5 * a_c * delta_t * delta_t;
+      double t_c = desired_duration_ - 2 * delta_t;
 
       // Segment B-C
       // Acceleration over this segment is zero
-      double v_B = (x_C - x_B) / t_C;
+      double v_b = (x_c - x_b) / t_c;
 
       // Segment A-B: don't change the polynomial-interpolated value, because we don't want to modify initial vel/accel
       // Segment B-C: flatten the curve by the factor, "flatten_factor"
       // Segment C-D: don't change the polynomial-interpolated value, because we don't want to modify final vel/accel
       for (size_t index = 2; index < static_cast<size_t>(times.size() - 2); ++index)
       {
-        double value_on_line = original_interpolated_position[index - 1] + v_B * delta_t;
+        double value_on_line = original_interpolated_position[index - 1] + v_b * delta_t;
         // Now decrease the difference between the polynomial and the line interpolation
         double new_value = value_on_line + flatten_factor * (original_interpolated_position[index] - value_on_line);
 

--- a/test/trajectory_generation_test.cpp
+++ b/test/trajectory_generation_test.cpp
@@ -193,8 +193,8 @@ TEST_F(TrajectoryGenerationTest, EasyLinearTrajectory)
 {
   // TrackJoint just needs to maintain the initial velocity to arrive at the goal
 
-  const double kDesiredDuration = 1;
-  const double kMaxDuration = 1;
+  const double desired_duration = 1;
+  const double max_duration = 1;
 
   std::vector<trackjoint::KinematicState> current_joint_states = current_joint_states_;
   trackjoint::KinematicState joint_state;
@@ -222,25 +222,25 @@ TEST_F(TrajectoryGenerationTest, EasyLinearTrajectory)
   limits.push_back(single_joint_limits);
   limits.push_back(single_joint_limits);
 
-  trackjoint::TrajectoryGenerator traj_gen(num_dof_, timestep_, kDesiredDuration, kMaxDuration, current_joint_states,
+  trackjoint::TrajectoryGenerator traj_gen(num_dof_, timestep_, desired_duration, max_duration, current_joint_states,
                                            goal_joint_states, limits, position_tolerance_, use_streaming_mode_);
   std::vector<trackjoint::JointTrajectory> output_trajectories(num_dof_);
-  traj_gen.GenerateTrajectories(&output_trajectories);
+  traj_gen.generateTrajectories(&output_trajectories);
 
-  EXPECT_EQ(ErrorCodeEnum::kNoError, traj_gen.GenerateTrajectories(&output_trajectories));
+  EXPECT_EQ(ErrorCodeEnum::kNoError, traj_gen.generateTrajectories(&output_trajectories));
 
   // Position error
   double position_tolerance = 1e-4;
   double position_error = trackjoint::CalculatePositionAccuracy(goal_joint_states, output_trajectories);
   EXPECT_LT(position_error, position_tolerance);
   // Duration
-  const double kDurationTolerance = 5e-3;
+  const double duration_tolerance = 5e-3;
   size_t vector_length = output_trajectories[0].elapsed_times.size() - 1;
-  EXPECT_NEAR(output_trajectories[0].elapsed_times(vector_length), kDesiredDuration, kDurationTolerance);
+  EXPECT_NEAR(output_trajectories[0].elapsed_times(vector_length), desired_duration, duration_tolerance);
   // Timestep
-  const double kTimestepTolerance = 0.0005;
+  const double timestep_tolerance = 0.0005;
   EXPECT_NEAR(output_trajectories[0].elapsed_times[1] - output_trajectories[0].elapsed_times[0], timestep_,
-              kTimestepTolerance);
+              timestep_tolerance);
 }
 
 TEST_F(TrajectoryGenerationTest, OneTimestepDuration)


### PR DESCRIPTION
Maybe I've been hearing too much about Covid recently, but this implements a "flatten the curve" method to reduce overshoot. Basically it reduces the amplitude of the oscillations of the interpolation polynomial. There's a document attached that shows how it works. Basically it moves the polynomial toward a linear interpolation if it can do so without breaking the vel/accel/jerk limits.

I tried triangular, trapezoidal, and linear interpolation prior to this, but they all had issues I couldn't figure out. Even looked into Bezier curves.

Miraculously all of the tests and demo code still passes. `flatten_factor.jpg` shows how much the curve was flattened for all of the tests. In the best case, the flattening factor was 70% -- so a 30% reduction in overshoot. That's not bad.


![flatten_the_curve](https://user-images.githubusercontent.com/11284393/79092460-9c1b2a80-7d16-11ea-8180-112d8b3df48b.jpg)
![flatten_factor](https://user-images.githubusercontent.com/11284393/79092461-9cb3c100-7d16-11ea-8782-53daef4c4d58.png)