### PR TITLE
Simple fix to backwardLimitComp if/else

### DIFF
--- a/src/single_joint_generator.cpp
+++ b/src/single_joint_generator.cpp
@@ -333,9 +333,9 @@ bool SingleJointGenerator::backwardLimitCompensation(size_t limited_index, doubl
           break;
         }
       }
-      // else, can't make all of the correction in this timestep, so make as
-      // much of a change as possible
-      else
+
+      // Can't make all of the correction in this timestep, so make as much of a change as possible
+      if (!successful_compensation)
       {
         // This is what accel and jerk would be if we set velocity(index) to the
         // limit


### PR DESCRIPTION
The `else` condition wasn't catching everything it should have. This PR should help performance get closer to optimal.

If the `if` at L297 was false, the function would move on to the next waypoint without making as much of an adjustment as possible at the current waypoint.

I'll make a PR to sync TrackPose if this gets approved