### PR TITLE
single_joint_generator:  Remove trailing `_` from function parameter

### DIFF
--- a/src/single_joint_generator.cpp
+++ b/src/single_joint_generator.cpp
@@ -534,7 +534,7 @@ ErrorCodeEnum SingleJointGenerator::positionVectorLimitLookAhead(size_t* index_l
     return error_code;
 
   // Helpful hint if limit comp fails on the first waypoint
-  if (index_last_successful_ == 1)
+  if (*index_last_successful == 1)
   {
     std::cout << "Limit compensation failed at the first waypoint. "
               << "Try a larger position_tolerance parameter or smaller timestep." << std::endl;


### PR DESCRIPTION
Fixup for 7c937adc

@AndyZe I'm guessing this was unintentional; if not, just close the PR without merging.  Thanks!