### PR TITLE
.travis.yml:  Add code-coverage check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
       - TEST=clang-format    # check code formatting for compliance to .clang-format rules
       - TEST=clang-tidy-fix  # perform static code analysis and compliance check against .clang-tidy rules
       - TEST=catkin_lint     # perform catkin_lint checks
+      - TEST=code-coverage   # check test coverage
       # pull in packages from a local .rosinstall file
       - UPSTREAM_WORKSPACE=trackjoint.rosinstall
 


### PR DESCRIPTION
Testing code coverage in CI.

Ignore this.  (This is marked as a "draft" because my private GH fork can't be built on the free Travis CI plan.)