### PR TITLE
Use splines in the jerk derivative calculation

### DIFF
--- a/include/trackjoint/single_joint_generator.h
+++ b/include/trackjoint/single_joint_generator.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include <cmath>                      // copysign
+#include <cmath>  // copysign
 #include "trackjoint/error_codes.h"
 #include "trackjoint/joint_trajectory.h"
 #include "trackjoint/kinematic_state.h"
@@ -42,7 +42,6 @@
 
 namespace trackjoint
 {
-
 class SingleJointGenerator
 {
 public:

--- a/include/trackjoint/single_joint_generator.h
+++ b/include/trackjoint/single_joint_generator.h
@@ -33,7 +33,6 @@
 #pragma once
 
 #include <cmath>                      // copysign
-#include <unsupported/Eigen/Splines>  // Spline-fitting is used to extend trajectory duration
 #include "trackjoint/error_codes.h"
 #include "trackjoint/joint_trajectory.h"
 #include "trackjoint/kinematic_state.h"
@@ -43,8 +42,6 @@
 
 namespace trackjoint
 {
-typedef Eigen::Spline<double, 1, 2> Spline1D;
-typedef Eigen::SplineFitting<Spline1D> SplineFitting1D;
 
 class SingleJointGenerator
 {

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -34,13 +34,19 @@
 
 #include <Eigen/Dense>
 #include <iostream>
+// Spline-fitting is used to extend trajectory duration and in derivative calculation
+#include <unsupported/Eigen/Splines>
 #include <vector>
 #include "trackjoint/joint_trajectory.h"
 
 namespace trackjoint
 {
+// Use a 3rd-degree spline to fit points well without excessive oscillations
+typedef Eigen::Spline<double, 1 /* dimension */, 3 /* degree */> Spline1D;
+typedef Eigen::SplineFitting<Spline1D> SplineFitting1D;
+
 /**
- * \brief Discrete differentiation of a vector. Fast but noisy.
+ * \brief Discrete differentiation of a vector. This is faster but noisier than the spline version.
  *
  * input input_vector any vector, such as position
  * input timestep the time between consecutive elements
@@ -62,6 +68,16 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, con
  */
 Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
                                                      const double first_element, const double filter_coefficient);
+
+/**
+ * \brief Discrete differentiation of a vector. Fast but noisy.
+ *
+ * input input_vector any vector, such as position
+ * input timestep the time between consecutive elements
+ * input first_element supply an initial condition
+ * return a vector of derivatives
+ */
+Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element);
 
 /** \brief Print desired duration, number of waypoints, timestep, initial state, and final state of a trajectory
  *

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -41,8 +41,8 @@
 
 namespace trackjoint
 {
-// Use a 3rd-degree spline to fit points well without excessive oscillations
-typedef Eigen::Spline<double, 1 /* dimension */, 3 /* degree */> Spline1D;
+// Default to use spline of dynamic degree
+typedef Eigen::Spline<double, 1 /* dimension */> Spline1D;
 typedef Eigen::SplineFitting<Spline1D> SplineFitting1D;
 
 /**
@@ -70,7 +70,15 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
                                                      const double first_element, const double filter_coefficient);
 
 /**
- * \brief Discrete differentiation of a vector. Fast but noisy.
+ * \brief Normalize a vector between 0 and 1
+ *
+ * input input_vector any vector, such as position
+ * return a vector of normalized values between 0 and 1
+ */
+Eigen::VectorXd normalize(const Eigen::VectorXd& x);
+
+/**
+ * \brief Interpolate with splines then take the derivative.
  *
  * input input_vector any vector, such as position
  * input timestep the time between consecutive elements

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -46,6 +46,38 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, dou
   return derivative;
 };
 
+// TODO(andyz): This is horribly inefficient. Maybe it would be best to store everything as splines always.
+// Also (maybe) to store everything in one large matrix with columns for each derivative.
+Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element)
+{
+  // Fit a spline through the input vector
+  size_t num_points = input_vector.size();
+  Eigen::RowVectorXd times = Eigen::RowVectorXd::Zero(num_points);
+  Eigen::RowVectorXd input_row = Eigen::RowVectorXd::Zero(num_points);
+  for (size_t i = 1; i < num_points; ++i)
+  {
+    input_row(i) = input_vector(i);
+    times(i) = times(i-1) + timestep;
+  }
+
+  const auto fit = SplineFitting1D::Interpolate(input_row, 3, times);
+
+  // Derivative output
+  Eigen::RowVectorXd derivative = Eigen::RowVectorXd::Zero(num_points);
+  derivative(0) = first_element;
+
+  // Take derivatives
+  double path_fraction = 0.0;
+  for (size_t point = 1; point < num_points; ++point)
+  {
+    path_fraction = (double)point / (double)num_points;
+    derivative[point] =
+      fit.derivatives(path_fraction, 1 /* order */)(1 /* first derivative */);
+  }
+
+  return derivative.transpose();
+}
+
 Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
                                                      const double first_element, const double filter_coefficient)
 {
@@ -56,7 +88,7 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
 
   // Filter from front to back
   filter.reset(derivative(0));
-  for (size_t point = 1; point < derivative.size(); ++point)
+  for (long unsigned int point = 1; point < derivative.size(); ++point)
   {
     // Lowpass filter the position command
     derivative(point) = filter.filter(derivative(point));


### PR DESCRIPTION
This is an attempt to make the jerk derivative calculation less noisy. But, it increases runtime a lot and produces nan's often, so I don't recommend merging it. Good to keep as a reference for how this can be done in the future, though.