### PR TITLE
Add a low-pass filter to derivative calculations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,9 @@ include_directories(
 
 set(LIBRARY_NAME trackjoint)
 add_library(${LIBRARY_NAME} SHARED
-  src/trajectory_generator.cpp
+  src/butterworth_filter.cpp
   src/single_joint_generator.cpp
+  src/trajectory_generator.cpp
   src/utilities.cpp
 )
 set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")

--- a/include/trackjoint/butterworth_filter.h
+++ b/include/trackjoint/butterworth_filter.h
@@ -68,4 +68,4 @@ private:
   double scale_term_;
   double feedback_term_;
 };
-}
+}  // namespace trackjoint

--- a/include/trackjoint/butterworth_filter.h
+++ b/include/trackjoint/butterworth_filter.h
@@ -1,0 +1,71 @@
+// Copyright 2022 PickNik Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the PickNik Inc. nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+/* Author: Andy Zelenak
+   Desc: A Butterworth low-pass filter.
+*/
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+namespace trackjoint
+{
+/**
+ * Class ButterworthFilter - Implementation of a signal filter to reduce noise.
+ * This is a first-order Butterworth low-pass filter. First-order was chosen for 2 reasons:
+ * - It doesn't overshoot
+ * - Computational efficiency
+ */
+class ButterworthFilter
+{
+public:
+  /**
+   * Constructor.
+   * @param low_pass_filter_coeff Larger filter_coeff-> more smoothing of servo commands, but more lag.
+   * Rough plot, with cutoff frequency on the y-axis:
+   * https://www.wolframalpha.com/input/?i=plot+arccot(c)
+   */
+  ButterworthFilter(double low_pass_filter_coeff);
+  ButterworthFilter() = delete;
+
+  double filter(double new_measurement);
+
+  void reset(const double data);
+
+private:
+  static constexpr size_t FILTER_LENGTH = 2;
+  std::array<double, FILTER_LENGTH> previous_measurements_;
+  double previous_filtered_measurement_;
+  // Scale and feedback term are calculated from supplied filter coefficient
+  double scale_term_;
+  double feedback_term_;
+};
+}

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -40,15 +40,30 @@
 namespace trackjoint
 {
 /**
- * \brief Discrete differentiation of a vector
+ * \brief Discrete differentiation of a vector. Fast but noisy.
  *
  * input input_vector any vector, such as position
  * input timestep the time between consecutive elements
  * input first_element supply an initial condition
  * return a vector of derivatives
  */
-// TODO(602): Overload DiscreteDifferentiation to take starting index
-Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element);
+Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector,
+                                        const double timestep, double first_element);
+
+/**
+ * \brief Discrete differentiation of a vector followed by low-pass filtering.
+ * This reduces signal noise.
+ *
+ * input input_vector any vector, such as position
+ * input timestep the time between consecutive elements
+ * input first_element supply an initial condition
+ * input filter_coefficient must be >1.0, typically less than 100. Larger value -> more smoothing.
+ * return a vector of derivatives
+ */
+Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector,
+                                                     const double timestep,
+                                                     const double first_element,
+                                                     const double filter_coefficient);
 
 /** \brief Print desired duration, number of waypoints, timestep, initial state, and final state of a trajectory
  *

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -47,8 +47,8 @@ namespace trackjoint
  * input first_element supply an initial condition
  * return a vector of derivatives
  */
-Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector,
-                                        const double timestep, double first_element);
+Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, const double timestep,
+                                        const double first_element);
 
 /**
  * \brief Discrete differentiation of a vector followed by low-pass filtering.
@@ -60,10 +60,8 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector,
  * input filter_coefficient must be >1.0, typically less than 100. Larger value -> more smoothing.
  * return a vector of derivatives
  */
-Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector,
-                                                     const double timestep,
-                                                     const double first_element,
-                                                     const double filter_coefficient);
+Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
+                                                     const double first_element, const double filter_coefficient);
 
 /** \brief Print desired duration, number of waypoints, timestep, initial state, and final state of a trajectory
  *

--- a/src/butterworth_filter.cpp
+++ b/src/butterworth_filter.cpp
@@ -1,0 +1,92 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Andy Zelenak
+   Description: A first-order Butterworth low-pass filter. There is only one parameter to tune.
+ */
+
+#include "trackjoint/butterworth_filter.h"
+
+namespace trackjoint
+{
+namespace
+{
+constexpr double EPSILON = 1e-9;
+}
+
+ButterworthFilter::ButterworthFilter(double low_pass_filter_coeff)
+  : previous_measurements_{ 0., 0. }
+  , previous_filtered_measurement_(0.)
+  , scale_term_(1. / (1. + low_pass_filter_coeff))
+  , feedback_term_(1. - low_pass_filter_coeff)
+{
+  // guarantee this doesn't change because the logic below depends on this length implicitly
+  static_assert(ButterworthFilter::FILTER_LENGTH == 2,
+                "online_signal_smoothing::ButterworthFilter::FILTER_LENGTH should be 2");
+
+  if (std::isinf(feedback_term_))
+    throw std::length_error("online_signal_smoothing::ButterworthFilter: infinite feedback_term_");
+
+  if (std::isinf(scale_term_))
+    throw std::length_error("online_signal_smoothing::ButterworthFilter: infinite scale_term_");
+
+  if (low_pass_filter_coeff < 1)
+    throw std::length_error(
+        "online_signal_smoothing::ButterworthFilter: Filter coefficient < 1. makes the lowpass filter unstable");
+
+  if (std::abs(feedback_term_) < EPSILON)
+    throw std::length_error(
+        "online_signal_smoothing::ButterworthFilter: Filter coefficient value resulted in feedback term of 0");
+}
+
+double ButterworthFilter::filter(double new_measurement)
+{
+  // Push in the new measurement
+  previous_measurements_[1] = previous_measurements_[0];
+  previous_measurements_[0] = new_measurement;
+
+  previous_filtered_measurement_ = scale_term_ * (previous_measurements_[1] + previous_measurements_[0] -
+                                                  feedback_term_ * previous_filtered_measurement_);
+
+  return previous_filtered_measurement_;
+}
+
+void ButterworthFilter::reset(const double data)
+{
+  previous_measurements_[0] = data;
+  previous_measurements_[1] = data;
+  previous_filtered_measurement_ = data;
+}
+
+}  // namespace trackjoint

--- a/src/single_joint_generator.cpp
+++ b/src/single_joint_generator.cpp
@@ -30,10 +30,9 @@
 
 namespace trackjoint
 {
-
 namespace
 {
-  constexpr double DEFAULT_FILTER_COEFFICIENT = 2.0;
+constexpr double DEFAULT_FILTER_COEFFICIENT = 2.0;
 }
 
 SingleJointGenerator::SingleJointGenerator(size_t num_waypoints_threshold, size_t max_num_waypoints_trajectory_mode)
@@ -609,20 +608,18 @@ ErrorCodeEnum SingleJointGenerator::positionVectorLimitLookAhead(size_t* index_l
 void SingleJointGenerator::calculateDerivativesFromPosition()
 {
   // From position vector, approximate vel/accel/jerk.
-  waypoints_.velocities =
-      DiscreteDifferentiationWithFiltering(waypoints_.positions, configuration_.timestep,
-        current_joint_state_.velocity, DEFAULT_FILTER_COEFFICIENT);
+  waypoints_.velocities = DiscreteDifferentiationWithFiltering(
+      waypoints_.positions, configuration_.timestep, current_joint_state_.velocity, DEFAULT_FILTER_COEFFICIENT);
   calculateDerivativesFromVelocity();
 }
 
 void SingleJointGenerator::calculateDerivativesFromVelocity()
 {
   // From velocity vector, approximate accel/jerk.
-  waypoints_.accelerations =
-      DiscreteDifferentiationWithFiltering(waypoints_.velocities, configuration_.timestep,
-        current_joint_state_.acceleration, DEFAULT_FILTER_COEFFICIENT);
-  waypoints_.jerks = DiscreteDifferentiationWithFiltering(waypoints_.accelerations,
-    configuration_.timestep, 0.0 /*initial value*/, DEFAULT_FILTER_COEFFICIENT);
+  waypoints_.accelerations = DiscreteDifferentiationWithFiltering(
+      waypoints_.velocities, configuration_.timestep, current_joint_state_.acceleration, DEFAULT_FILTER_COEFFICIENT);
+  waypoints_.jerks = DiscreteDifferentiationWithFiltering(waypoints_.accelerations, configuration_.timestep,
+                                                          0.0 /*initial value*/, DEFAULT_FILTER_COEFFICIENT);
 }
 
 void SingleJointGenerator::updateTrajectoryDuration(double new_trajectory_duration)

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -31,7 +31,7 @@
 
 namespace trackjoint
 {
-Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element)
+Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, double timestep, const double first_element)
 {
   // derivative = (difference between adjacent elements) / timestep
   Eigen::VectorXd input_shifted_right(input_vector.size());
@@ -46,10 +46,8 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, dou
   return derivative;
 };
 
-Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector,
-                                                     const double timestep,
-                                                     const double first_element,
-                                                     const double filter_coefficient)
+Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
+                                                     const double first_element, const double filter_coefficient)
 {
   Eigen::VectorXd derivative = DiscreteDifferentiation(input_vector, timestep, first_element);
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -53,9 +53,18 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
 
   // Apply a low-pass filter
   ButterworthFilter filter(filter_coefficient);
-  // Set the initial value
+
+  // Filter from front to back
   filter.reset(derivative(0));
   for (size_t point = 1; point < derivative.size(); ++point)
+  {
+    // Lowpass filter the position command
+    derivative(point) = filter.filter(derivative(point));
+  }
+
+  // Now filter from back to front to eliminate phase shift
+  filter.reset(derivative(derivative.size() - 1));
+  for (size_t point = derivative.size() - 2; point > 0; --point)
   {
     // Lowpass filter the position command
     derivative(point) = filter.filter(derivative(point));

--- a/test/trajectory_generation_test.cpp
+++ b/test/trajectory_generation_test.cpp
@@ -546,6 +546,7 @@ TEST_F(TrajectoryGenerationTest, NoisyStreamingCommand)
 
   double time = 0;
   // Create Trajectory Generator object
+  use_streaming_mode_ = true;
   TrajectoryGenerator traj_gen(num_dof_, timestep_, desired_duration_, max_duration_, current_joint_states_,
                                goal_joint_states_, limits_, position_tolerance_, use_streaming_mode_);
 


### PR DESCRIPTION
This makes the derivative calculations much less noisy and hardly affects runtime at all.

For example, prior to this PR, the run time for simple_streaming_example was 0.00448s. After this PR it was 0.00481s.

It seems to have positive effects on the unit tests. @stephanie-eng you can comment this line in trajectory_generator.cpp to see how it really performs (we probably should make this configurable for testing somehow):

```
  // To be on the safe side, ensure limits are obeyed
  clipVectorsForOutput(output_trajectories);
```

From what I see, it gets your new tests much closer to passing:

```
- trackjoint.TrajectoryGenerationTest VelocityLimit

Expected: (trajectory.at(joint).velocities.cwiseAbs().maxCoeff()) <= (limits[joint].velocity_limit), actual: 1.03728 vs 1

- trackjoint.TrajectoryGenerationTest AccelerationLimit

    Expected: (trajectory.at(joint).accelerations.cwiseAbs().maxCoeff()) <= (limits[joint].acceleration_limit), actual: 8.4161 vs 5
```