### PR TITLE
Normalize x before fitting spline

### DIFF
--- a/include/trackjoint/single_joint_generator.h
+++ b/include/trackjoint/single_joint_generator.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#include <cmath>                      // copysign
+#include <cmath>  // copysign
 #include "trackjoint/error_codes.h"
 #include "trackjoint/joint_trajectory.h"
 #include "trackjoint/kinematic_state.h"
@@ -42,7 +42,6 @@
 
 namespace trackjoint
 {
-
 class SingleJointGenerator
 {
 public:

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -41,8 +41,8 @@
 
 namespace trackjoint
 {
-// Use a 3rd-degree spline to fit points well without excessive oscillations
-typedef Eigen::Spline<double, 1 /* dimension */, 3 /* degree */> Spline1D;
+// Default to use spline of dyanmic degree
+typedef Eigen::Spline<double, 1 /* dimension */> Spline1D;
 typedef Eigen::SplineFitting<Spline1D> SplineFitting1D;
 
 /**
@@ -54,6 +54,14 @@ typedef Eigen::SplineFitting<Spline1D> SplineFitting1D;
  * return a vector of derivatives
  */
 Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element);
+
+/**
+ * \brief Normalize a vector between 0 and 1
+ *
+ * input input_vector any vector, such as position
+ * return a vector of normalized values between 0 and 1
+ */
+Eigen::VectorXd normalize(const Eigen::VectorXd& x);
 
 /**
  * \brief Interpolate with splines then take the derivative.

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -41,7 +41,7 @@
 
 namespace trackjoint
 {
-// Default to use spline of dyanmic degree
+// Default to use spline of dynamic degree
 typedef Eigen::Spline<double, 1 /* dimension */> Spline1D;
 typedef Eigen::SplineFitting<Spline1D> SplineFitting1D;
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -45,6 +45,21 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, dou
   return derivative;
 };
 
+Eigen::VectorXd normalize(const Eigen::VectorXd& x)
+{
+  const double min = x.minCoeff();
+  const double max = x.maxCoeff();
+  size_t num_points = x.size();
+  Eigen::VectorXd x_norm = Eigen::RowVectorXd::Zero(num_points);
+
+  for (size_t i = 0; i < num_points; i++)
+  {
+    x_norm(i) = (x(i) - min) / (max - min);
+  }
+
+  return x_norm;
+}
+
 // TODO(andyz): This is horribly inefficient. Maybe it would be best to store everything as splines always.
 // Also (maybe) to store everything in one large matrix with columns for each derivative.
 Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element)
@@ -56,10 +71,12 @@ Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, doubl
   for (size_t i = 1; i < num_points; ++i)
   {
     input_row(i) = input_vector(i);
-    times(i) = times(i-1) + timestep;
+    times(i) = times(i - 1) + timestep;
   }
 
-  const auto fit = SplineFitting1D::Interpolate(input_row, 3, times);
+  const auto knots = normalize(times);
+  const auto fit = SplineFitting1D::Interpolate(input_row, 3, knots);
+  double scale = 1 / (times.maxCoeff() - times.minCoeff());
 
   // Derivative output
   Eigen::RowVectorXd derivative = Eigen::RowVectorXd::Zero(num_points);
@@ -70,8 +87,7 @@ Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, doubl
   for (size_t point = 1; point < num_points; ++point)
   {
     path_fraction = (double)point / (double)num_points;
-    derivative[point] =
-      fit.derivatives(path_fraction, 1 /* order */)(1 /* first derivative */);
+    derivative[point] = fit.derivatives(path_fraction, 1 /* order */)(1 /* first derivative */) * scale;
   }
 
   return derivative.transpose();

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -50,13 +50,9 @@ Eigen::VectorXd normalize(const Eigen::VectorXd& x)
   const double min = x.minCoeff();
   const double max = x.maxCoeff();
   size_t num_points = x.size();
-  Eigen::VectorXd x_norm = Eigen::RowVectorXd::Zero(num_points);
+  Eigen::RowVectorXd x_norm = Eigen::RowVectorXd::Zero(num_points);
 
-  for (size_t i = 0; i < num_points; i++)
-  {
-    x_norm(i) = (x(i) - min) / (max - min);
-  }
-
+  x_norm = (x.array() - min) / (max - min);
   return x_norm;
 }
 


### PR DESCRIPTION
A few things I found - figured it would be easier to show in a branch rather than discuss through comments.

Changes:

1. Use spline of dynamic degree - not sure why this is needed, but using otherwise will create a bunch of NaN values. In my minimal example, I was able to use 3 without issue.
2. Added a normalize function and normalized the time (x) vector between 0 and 1 and pass that as the knot parameters for the spline before fitting
3. Scaled the derivative to compensate for normalization. Note that if we ever want to get the second derivative, we need to consider the change of variable x = (x - x_min) / (x_max - x_min) and any chain rule connotations that has.

Before normalizing the times, the spline fit is quite poor:
![spline-unnormalized](https://user-images.githubusercontent.com/10466537/151040055-1e106d68-c692-4e81-8b55-f6d46b4f2378.png)

After passing in normalized tine as knots:
![normalized-spline](https://user-images.githubusercontent.com/10466537/151040084-6243664c-ec99-456a-8fd2-dc82c27c7a30.png)

To show that the derivative is what we expect, I made a minimal example. Here's a plot of sin(x), a spline fitted with a normalized x for knots, and a spline fitted using x as knots. It's hard to see, but the blue line is behind the yellow line:
![sinx-splines](https://user-images.githubusercontent.com/10466537/151040323-85e37568-1218-47cf-8d48-0bbe5427dcec.png)

And the derivatives, expected to be cosine. Once again, the blue line is behind the yellow line.
![dsinx-splines](https://user-images.githubusercontent.com/10466537/151040347-74a559d5-d28c-4110-b04a-862e46932ed5.png)
(x):

It's worth noting that the end points of the spline will be off. We maybe should consider having the last spline use the not-a-knot condition if we dislike this behaviour.