### PR TITLE
Determine max num waypoints from max_duration and timestep args

### DIFF
--- a/include/trackjoint/trajectory_generator.h
+++ b/include/trackjoint/trajectory_generator.h
@@ -71,6 +71,26 @@ public:
                       const std::vector<KinematicState>& goal_joint_states, const std::vector<Limits>& limits,
                       const double position_tolerance, bool use_streaming_mode);
 
+  /** \brief Constructor
+   *
+   * input num_dof number of degrees of freedom
+   * input timestep desired time between waypoints
+   * input desired_duration total desired duration of the trajectory
+   * input max_duration allow the trajectory to be extended up to this limit. Error if that cannot be done.
+   * input current_joint_states vector of the initial kinematic states for each degree of freedom
+   * input goal_joint_states vector of the target kinematic states for each degree of freedom
+   * input limits vector of kinematic limits for each degree of freedom
+   * input position_tolerance tolerance for how close the final trajectory should follow a smooth interpolation.
+   *                          Should be set lower than the accuracy requirements for your task
+   * input use_streaming_mode set to true for fast streaming applications. Returns a maximum of kNumWaypointsThreshold
+   * waypoints.
+   * input size_t num_waypoints_threshold maximum number of waypoints, default is infinite
+   */
+  TrajectoryGenerator(uint num_dof, double timestep, double desired_duration, double max_duration,
+                      const std::vector<KinematicState>& current_joint_states,
+                      const std::vector<KinematicState>& goal_joint_states, const std::vector<Limits>& limits,
+                      const double position_tolerance, bool use_streaming_mode, size_t num_waypoints_threshold);
+
   /** \brief reset the member variables of the object and prepare to generate a new trajectory */
   void reset(double timestep, double desired_duration, double max_duration,
              const std::vector<KinematicState>& current_joint_states,
@@ -132,9 +152,6 @@ private:
    */
   ErrorCodeEnum synchronizeTrajComponents(std::vector<JointTrajectory>* output_trajectories);
 
-  // TODO(andyz): set this back to a small number when done testing
-  // TODO(709): Remove kMaxNumWaypointsFullTrajectory - not needed now that we have streaming mode
-  const size_t kMaxNumWaypointsFullTrajectory = 10000;  // A relatively small number, to run fast
   // Upsample for better accuracy if num waypoints is below threshold in full trajectory mode
   // Clip trajectories to threshold in streaming mode
   const size_t kNumWaypointsThreshold = 10;
@@ -151,5 +168,6 @@ private:
   std::vector<SingleJointGenerator> single_joint_generators_;
   size_t upsampled_num_waypoints_;
   size_t upsample_rounds_ = 0;  // Every time we upsample, timestep is halved. Track this.
-};                              // end class TrajectoryGenerator
+  const size_t kMaxNumWaypointsFullTrajectory;
+};  // end class TrajectoryGenerator
 }  // namespace trackjoint

--- a/include/trackjoint/trajectory_generator.h
+++ b/include/trackjoint/trajectory_generator.h
@@ -71,26 +71,6 @@ public:
                       const std::vector<KinematicState>& goal_joint_states, const std::vector<Limits>& limits,
                       const double position_tolerance, bool use_streaming_mode);
 
-  /** \brief Constructor
-   *
-   * input num_dof number of degrees of freedom
-   * input timestep desired time between waypoints
-   * input desired_duration total desired duration of the trajectory
-   * input max_duration allow the trajectory to be extended up to this limit. Error if that cannot be done.
-   * input current_joint_states vector of the initial kinematic states for each degree of freedom
-   * input goal_joint_states vector of the target kinematic states for each degree of freedom
-   * input limits vector of kinematic limits for each degree of freedom
-   * input position_tolerance tolerance for how close the final trajectory should follow a smooth interpolation.
-   *                          Should be set lower than the accuracy requirements for your task
-   * input use_streaming_mode set to true for fast streaming applications. Returns a maximum of kNumWaypointsThreshold
-   * waypoints.
-   * input size_t num_waypoints_threshold maximum number of waypoints, default is infinite
-   */
-  TrajectoryGenerator(uint num_dof, double timestep, double desired_duration, double max_duration,
-                      const std::vector<KinematicState>& current_joint_states,
-                      const std::vector<KinematicState>& goal_joint_states, const std::vector<Limits>& limits,
-                      const double position_tolerance, bool use_streaming_mode, size_t num_waypoints_threshold);
-
   /** \brief reset the member variables of the object and prepare to generate a new trajectory */
   void reset(double timestep, double desired_duration, double max_duration,
              const std::vector<KinematicState>& current_joint_states,
@@ -168,6 +148,5 @@ private:
   std::vector<SingleJointGenerator> single_joint_generators_;
   size_t upsampled_num_waypoints_;
   size_t upsample_rounds_ = 0;  // Every time we upsample, timestep is halved. Track this.
-  const size_t kMaxNumWaypointsFullTrajectory;
-};  // end class TrajectoryGenerator
+};                              // end class TrajectoryGenerator
 }  // namespace trackjoint

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -47,7 +47,7 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
 {
   // Upsample if num. waypoints would be short. Helps with accuracy
   upsample();
-  double max_num_waypoints = desired_duration / upsampled_timestep_;
+  double max_num_waypoints = max_duration / upsampled_timestep_;
 
   // Initialize a trajectory generator for each joint
   for (size_t joint = 0; joint < kNumDof; ++joint)

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -47,7 +47,7 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
 {
   // Upsample if num. waypoints would be short. Helps with accuracy
   upsample();
-  auto max_num_waypoints = desired_duration / upsampled_timestep_;
+  double max_num_waypoints = desired_duration / upsampled_timestep_;
 
   // Initialize a trajectory generator for each joint
   for (size_t joint = 0; joint < kNumDof; ++joint)

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -47,7 +47,7 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
 {
   // Upsample if num. waypoints would be short. Helps with accuracy
   upsample();
-  double max_num_waypoints = max_duration / upsampled_timestep_;
+  size_t max_num_waypoints = static_cast<size_t>(std::ceil( max_duration / upsampled_timestep_ ));
 
   // Initialize a trajectory generator for each joint
   for (size_t joint = 0; joint < kNumDof; ++joint)

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -36,16 +36,6 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
                                          const std::vector<KinematicState>& goal_joint_states,
                                          const std::vector<Limits>& limits, const double position_tolerance,
                                          bool use_streaming_mode)
-  : TrajectoryGenerator(num_dof, timestep, desired_duration, max_duration, current_joint_states, goal_joint_states,
-                        limits, position_tolerance, use_streaming_mode, std::numeric_limits<size_t>::max())
-{
-}
-
-TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double desired_duration, double max_duration,
-                                         const std::vector<KinematicState>& current_joint_states,
-                                         const std::vector<KinematicState>& goal_joint_states,
-                                         const std::vector<Limits>& limits, const double position_tolerance,
-                                         bool use_streaming_mode, size_t num_waypoints_threshold)
   : kNumDof(num_dof)
   , desired_timestep_(timestep)
   , upsampled_timestep_(timestep)
@@ -54,15 +44,15 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
   , current_joint_states_(current_joint_states)
   , limits_(limits)
   , use_streaming_mode_(use_streaming_mode)
-  , kMaxNumWaypointsFullTrajectory(num_waypoints_threshold)
 {
   // Upsample if num. waypoints would be short. Helps with accuracy
   upsample();
+  auto max_num_waypoints = desired_duration / upsampled_timestep_;
 
   // Initialize a trajectory generator for each joint
   for (size_t joint = 0; joint < kNumDof; ++joint)
   {
-    single_joint_generators_.push_back(SingleJointGenerator(kNumWaypointsThreshold, kMaxNumWaypointsFullTrajectory));
+    single_joint_generators_.push_back(SingleJointGenerator(kNumWaypointsThreshold, max_num_waypoints));
   }
 }
 
@@ -208,22 +198,6 @@ ErrorCodeEnum TrajectoryGenerator::inputChecking(const std::vector<KinematicStat
                                                  const std::vector<KinematicState>& goal_joint_states,
                                                  const std::vector<Limits>& limits, double nominal_timestep)
 {
-  if (desired_duration_ > kMaxNumWaypointsFullTrajectory * upsampled_timestep_)
-  {
-    // Print a warning but do not exit
-    std::cout << "Capping desired duration at " << kMaxNumWaypointsFullTrajectory
-              << " waypoints to maintain determinism." << std::endl;
-    desired_duration_ = kMaxNumWaypointsFullTrajectory * upsampled_timestep_;
-  }
-
-  if (max_duration_ > kMaxNumWaypointsFullTrajectory * upsampled_timestep_)
-  {
-    // Print a warning but do not exit
-    std::cout << "Capping max duration at " << kMaxNumWaypointsFullTrajectory << " waypoints to maintain determinism."
-              << std::endl;
-    max_duration_ = kMaxNumWaypointsFullTrajectory * upsampled_timestep_;
-  }
-
   double rounded_duration = std::round(desired_duration_ / upsampled_timestep_) * upsampled_timestep_;
 
   // Need at least 1 timestep

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -36,6 +36,16 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
                                          const std::vector<KinematicState>& goal_joint_states,
                                          const std::vector<Limits>& limits, const double position_tolerance,
                                          bool use_streaming_mode)
+  : TrajectoryGenerator(num_dof, timestep, desired_duration, max_duration, current_joint_states, goal_joint_states,
+                        limits, position_tolerance, use_streaming_mode, std::numeric_limits<size_t>::max())
+{
+}
+
+TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double desired_duration, double max_duration,
+                                         const std::vector<KinematicState>& current_joint_states,
+                                         const std::vector<KinematicState>& goal_joint_states,
+                                         const std::vector<Limits>& limits, const double position_tolerance,
+                                         bool use_streaming_mode, size_t num_waypoints_threshold)
   : kNumDof(num_dof)
   , desired_timestep_(timestep)
   , upsampled_timestep_(timestep)
@@ -44,6 +54,7 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
   , current_joint_states_(current_joint_states)
   , limits_(limits)
   , use_streaming_mode_(use_streaming_mode)
+  , kMaxNumWaypointsFullTrajectory(num_waypoints_threshold)
 {
   // Upsample if num. waypoints would be short. Helps with accuracy
   upsample();


### PR DESCRIPTION
Removes the `kMaxNumWaypointsFullTrajectory` limit in favour of determining it via `max_duration` / `timestep`
* Also removes some input checks that this change would make redundant