### PR TITLE
Consistency changes and cleanup

### DIFF
--- a/include/trackjoint/kinematic_state.h
+++ b/include/trackjoint/kinematic_state.h
@@ -51,14 +51,14 @@ public:
    */
   void print() const
   {
-    std::cout << "Position:" << std::endl;
-    std::cout << this->position << std::endl << std::endl;
+    std::cout << "Position:" << '\n';
+    std::cout << this->position << '\n' << '\n';
 
-    std::cout << "Velocity:" << std::endl;
-    std::cout << this->velocity << std::endl << std::endl;
+    std::cout << "Velocity:" << '\n';
+    std::cout << this->velocity << '\n' << '\n';
 
-    std::cout << "Acceleration:" << std::endl;
-    std::cout << this->acceleration << std::endl;
+    std::cout << "Acceleration:" << '\n';
+    std::cout << this->acceleration << '\n';
   }
 };
 }  // namespace trackjoint

--- a/include/trackjoint/kinematic_state.h
+++ b/include/trackjoint/kinematic_state.h
@@ -49,7 +49,7 @@ public:
 
   /** \brief Print this state
    */
-  void print()
+  void print() const
   {
     std::cout << "Position:" << std::endl;
     std::cout << this->position << std::endl << std::endl;

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -53,7 +53,7 @@ typedef Eigen::SplineFitting<Spline1D> SplineFitting1D;
  * input first_element supply an initial condition
  * return a vector of derivatives
  */
-Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, const double timestep,
+Eigen::VectorXd discreteDifferentiation(const Eigen::VectorXd& input_vector, const double timestep,
                                         const double first_element);
 
 /**
@@ -66,7 +66,7 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, con
  * input filter_coefficient must be >1.0, typically less than 100. Larger value -> more smoothing.
  * return a vector of derivatives
  */
-Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
+Eigen::VectorXd discreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
                                                      const double first_element, const double filter_coefficient);
 
 /**
@@ -75,7 +75,7 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
  * input input_vector any vector, such as position
  * return a vector of normalized values between 0 and 1
  */
-Eigen::VectorXd Normalize(const Eigen::VectorXd& x);
+Eigen::VectorXd normalize(const Eigen::VectorXd& x);
 
 /**
  * \brief Interpolate with splines then take the derivative.
@@ -85,7 +85,7 @@ Eigen::VectorXd Normalize(const Eigen::VectorXd& x);
  * input first_element supply an initial condition
  * return a vector of derivatives
  */
-Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element);
+Eigen::VectorXd splineDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element);
 
 /** \brief Print desired duration, number of waypoints, timestep, initial state, and final state of a trajectory
  *
@@ -93,12 +93,12 @@ Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, doubl
  * input output_trajectories the calculated trajectories for n joints
  * input desired_duration the user-requested duration of the trajectory
  */
-void PrintJointTrajectory(const std::size_t joint, const std::vector<JointTrajectory>& output_trajectories,
+void printJointTrajectory(const std::size_t joint, const std::vector<JointTrajectory>& output_trajectories,
                           const double desired_duration);
 
 /** \brief Clip all elements beyond a given size */
-void ClipEigenVector(Eigen::VectorXd* vector, size_t new_num_waypoints);
+void clipEigenVector(Eigen::VectorXd* vector, size_t new_num_waypoints);
 
 /* \brief Check if all elements of a vector are within a [low_limit, high_limit] range. */
-bool VerifyVectorWithinBounds(double low_limit, double high_limit, Eigen::VectorXd& vector);
+bool verifyVectorWithinBounds(double low_limit, double high_limit, Eigen::VectorXd& vector);
 }  // namespace trackjoint

--- a/include/trackjoint/utilities.h
+++ b/include/trackjoint/utilities.h
@@ -75,7 +75,7 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
  * input input_vector any vector, such as position
  * return a vector of normalized values between 0 and 1
  */
-Eigen::VectorXd normalize(const Eigen::VectorXd& x);
+Eigen::VectorXd Normalize(const Eigen::VectorXd& x);
 
 /**
  * \brief Interpolate with splines then take the derivative.

--- a/src/simple_example.cpp
+++ b/src/simple_example.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
   // This is the fastest possible trajectory execution time, assuming the robot starts at full velocity.
   double desired_duration =
       fabs(goal_joint_states[0].position - current_joint_states[0].position) / single_joint_limits.velocity_limit;
-  std::cout << "Desired duration: " << desired_duration << std::endl;
+  std::cout << "Desired duration: " << desired_duration << '\n';
 
   // This descibes how far TrackJoint can deviate from a smooth, interpolated polynomial.
   // It is used for calculations internally. It should be set to a smaller number than your task requires.
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
   // Input error handling - if an error is found, the trajectory is not generated.
   if (error_code != trackjoint::ErrorCodeEnum::NO_ERROR)
   {
-    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
     return -1;
   }
 
@@ -110,15 +110,15 @@ int main(int argc, char** argv)
   // Trajectory generation error handling
   if (error_code != trackjoint::ErrorCodeEnum::NO_ERROR)
   {
-    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
     return -1;
   }
 
   std::chrono::duration<double> elapsed_seconds = end - start;
 
-  std::cout << "Runtime: " << elapsed_seconds.count() << std::endl;
-  std::cout << "Num waypoints: " << output_trajectories.at(0).positions.size() << std::endl;
-  std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+  std::cout << "Runtime: " << elapsed_seconds.count() << '\n';
+  std::cout << "Num waypoints: " << output_trajectories.at(0).positions.size() << '\n';
+  std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
 
   // Save the synchronized trajectories to .csv files
   traj_gen.saveTrajectoriesToFile(output_trajectories, output_path_base);
@@ -127,22 +127,22 @@ int main(int argc, char** argv)
   // Note: waypoint[0] should match the user-supplied start state
   for (size_t joint = 0; joint < output_trajectories.size(); ++joint)
   {
-    std::cout << "==========" << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
-    std::cout << "==========" << std::endl;
-    std::cout << "Joint " << joint << std::endl;
-    std::cout << "==========" << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
-    std::cout << "==========" << std::endl;
+    std::cout << "==========" << '\n';
+    std::cout << '\n';
+    std::cout << '\n';
+    std::cout << "==========" << '\n';
+    std::cout << "Joint " << joint << '\n';
+    std::cout << "==========" << '\n';
+    std::cout << '\n';
+    std::cout << '\n';
+    std::cout << "==========" << '\n';
     for (size_t waypoint = 0; waypoint < static_cast<size_t>(output_trajectories.at(joint).positions.size()); ++waypoint)
     {
       std::cout << "Elapsed time: " << output_trajectories.at(joint).elapsed_times(waypoint)
                 << "  Position: " << output_trajectories.at(joint).positions(waypoint)
                 << "  Velocity: " << output_trajectories.at(joint).velocities(waypoint)
                 << "  Acceleration: " << output_trajectories.at(joint).accelerations(waypoint)
-                << "  Jerk: " << output_trajectories.at(joint).jerks(waypoint) << std::endl;
+                << "  Jerk: " << output_trajectories.at(joint).jerks(waypoint) << '\n';
     }
   }
 

--- a/src/single_joint_generator.cpp
+++ b/src/single_joint_generator.cpp
@@ -541,11 +541,11 @@ ErrorCodeEnum SingleJointGenerator::predictTimeToReach()
     if (index_last_successful_ + 1 < kNumWaypointsThreshold)
     {
       // If in streaming mode, clip at the shorter number of waypoints
-      ClipEigenVector(&waypoints_.positions, index_last_successful_ + 1);
-      ClipEigenVector(&waypoints_.velocities, index_last_successful_ + 1);
-      ClipEigenVector(&waypoints_.accelerations, index_last_successful_ + 1);
-      ClipEigenVector(&waypoints_.jerks, index_last_successful_ + 1);
-      ClipEigenVector(&waypoints_.elapsed_times, index_last_successful_ + 1);
+      clipEigenVector(&waypoints_.positions, index_last_successful_ + 1);
+      clipEigenVector(&waypoints_.velocities, index_last_successful_ + 1);
+      clipEigenVector(&waypoints_.accelerations, index_last_successful_ + 1);
+      clipEigenVector(&waypoints_.jerks, index_last_successful_ + 1);
+      clipEigenVector(&waypoints_.elapsed_times, index_last_successful_ + 1);
       // Eigen vectors do not have a "back" member function
       goal_joint_state_.position = waypoints_.positions[index_last_successful_];
       goal_joint_state_.velocity = waypoints_.velocities[index_last_successful_];
@@ -556,11 +556,11 @@ ErrorCodeEnum SingleJointGenerator::predictTimeToReach()
     else
     {
       // If in streaming mode, clip at the shorter number of waypoints
-      ClipEigenVector(&waypoints_.positions, kNumWaypointsThreshold);
-      ClipEigenVector(&waypoints_.velocities, kNumWaypointsThreshold);
-      ClipEigenVector(&waypoints_.accelerations, kNumWaypointsThreshold);
-      ClipEigenVector(&waypoints_.jerks, kNumWaypointsThreshold);
-      ClipEigenVector(&waypoints_.elapsed_times, kNumWaypointsThreshold);
+      clipEigenVector(&waypoints_.positions, kNumWaypointsThreshold);
+      clipEigenVector(&waypoints_.velocities, kNumWaypointsThreshold);
+      clipEigenVector(&waypoints_.accelerations, kNumWaypointsThreshold);
+      clipEigenVector(&waypoints_.jerks, kNumWaypointsThreshold);
+      clipEigenVector(&waypoints_.elapsed_times, kNumWaypointsThreshold);
       // Eigen vectors do not have a "back" member function
       goal_joint_state_.position = waypoints_.positions[kNumWaypointsThreshold - 1];
       goal_joint_state_.velocity = waypoints_.velocities[kNumWaypointsThreshold - 1];
@@ -612,7 +612,7 @@ ErrorCodeEnum SingleJointGenerator::positionVectorLimitLookAhead(size_t* index_l
 void SingleJointGenerator::calculateDerivativesFromPosition()
 {
   // From position vector, approximate vel/accel/jerk.
-  waypoints_.velocities = DiscreteDifferentiationWithFiltering(
+  waypoints_.velocities = discreteDifferentiationWithFiltering(
       waypoints_.positions, configuration_.timestep, current_joint_state_.velocity, DEFAULT_FILTER_COEFFICIENT);
   calculateDerivativesFromVelocity();
 }
@@ -620,9 +620,9 @@ void SingleJointGenerator::calculateDerivativesFromPosition()
 void SingleJointGenerator::calculateDerivativesFromVelocity()
 {
   // From velocity vector, approximate accel/jerk.
-  waypoints_.accelerations = DiscreteDifferentiationWithFiltering(
+  waypoints_.accelerations = discreteDifferentiationWithFiltering(
       waypoints_.velocities, configuration_.timestep, current_joint_state_.acceleration, DEFAULT_FILTER_COEFFICIENT);
-  waypoints_.jerks = DiscreteDifferentiationWithFiltering(waypoints_.accelerations, configuration_.timestep,
+  waypoints_.jerks = discreteDifferentiationWithFiltering(waypoints_.accelerations, configuration_.timestep,
                                                           0.0 /*initial value*/, DEFAULT_FILTER_COEFFICIENT);
 }
 

--- a/src/streaming_example.cpp
+++ b/src/streaming_example.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
     return -1;
   }
   std::cout << "Initial trajectory calculation:" << '\n';
-  PrintJointTrajectory(joint, output_trajectories, desired_duration);
+  printJointTrajectory(joint, output_trajectories, desired_duration);
 
   // Update the start state with the next waypoint
   start_state[joint].position = output_trajectories.at(joint).positions[next_waypoint];
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
     }
 
     // Print the synchronized trajectories
-    PrintJointTrajectory(joint, output_trajectories, desired_duration);
+    printJointTrajectory(joint, output_trajectories, desired_duration);
 
     // Move forward one waypoint for the next iteration
     if ((std::size_t)output_trajectories.at(joint).positions.size() > next_waypoint)

--- a/src/streaming_example.cpp
+++ b/src/streaming_example.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
   trackjoint::ErrorCodeEnum error_code = traj_gen.inputChecking(start_state, goal_joint_states, limits, timestep);
   if (error_code)
   {
-    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
     return -1;
   }
 
@@ -100,10 +100,10 @@ int main(int argc, char** argv)
   error_code = traj_gen.generateTrajectories(&output_trajectories);
   if (error_code != trackjoint::ErrorCodeEnum::NO_ERROR)
   {
-    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
     return -1;
   }
-  std::cout << "Initial trajectory calculation:" << std::endl;
+  std::cout << "Initial trajectory calculation:" << '\n';
   PrintJointTrajectory(joint, output_trajectories, desired_duration);
 
   // Update the start state with the next waypoint
@@ -130,11 +130,11 @@ int main(int argc, char** argv)
 
     auto end_time = std::chrono::high_resolution_clock::now();
     std::cout << "Run time (microseconds): "
-              << std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count() << std::endl;
+              << std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time).count() << '\n';
 
     if (error_code != trackjoint::ErrorCodeEnum::NO_ERROR)
     {
-      std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+      std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
       return -1;
     }
 
@@ -151,7 +151,7 @@ int main(int argc, char** argv)
     else
     {
       // This should never happen
-      std::cout << "Index error!" << std::endl;
+      std::cout << "Index error!" << '\n';
       return 1;
     }
 
@@ -170,7 +170,7 @@ int main(int argc, char** argv)
     desired_duration = std::max(desired_duration, min_desired_duration);
   }
 
-  std::cout << "Done!" << std::endl;
+  std::cout << "Done!" << '\n';
 
   return 0;
 }

--- a/src/three_dof_examples.cpp
+++ b/src/three_dof_examples.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
   // This is the fastest possible trajectory execution time, assuming the robot starts at full velocity.
   double desired_duration =
       fabs(goal_joint_states[1].position - current_joint_states[1].position) / single_joint_limits.velocity_limit;
-  std::cout << "Desired duration: " << desired_duration << std::endl;
+  std::cout << "Desired duration: " << desired_duration << '\n';
 
   // Initialize main class
   trackjoint::TrajectoryGenerator traj_gen(num_dof, timestep, desired_duration, max_duration, current_joint_states,
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
   // generated.
   if (error_code != trackjoint::ErrorCodeEnum::NO_ERROR)
   {
-    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
     return -1;
   }
 
@@ -116,15 +116,15 @@ int main(int argc, char** argv)
   // Trajectory generation error handling
   if (error_code != trackjoint::ErrorCodeEnum::NO_ERROR)
   {
-    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+    std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
     return -1;
   }
 
   std::chrono::duration<double> elapsed_seconds = end - start;
 
-  std::cout << "Runtime: " << elapsed_seconds.count() << std::endl;
-  std::cout << "Num waypoints: " << output_trajectories.at(0).positions.size() << std::endl;
-  std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+  std::cout << "Runtime: " << elapsed_seconds.count() << '\n';
+  std::cout << "Num waypoints: " << output_trajectories.at(0).positions.size() << '\n';
+  std::cout << "Error code: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
 
   // Save the synchronized trajectories to .csv files
   traj_gen.saveTrajectoriesToFile(output_trajectories, output_path_base);
@@ -132,25 +132,25 @@ int main(int argc, char** argv)
   // Print the synchronized trajectories
   for (size_t joint = 0; joint < output_trajectories.size(); ++joint)
   {
-    std::cout << "==========" << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
-    std::cout << "==========" << std::endl;
-    std::cout << "Joint " << joint << std::endl;
-    std::cout << "==========" << std::endl;
-    std::cout << std::endl;
-    std::cout << std::endl;
-    std::cout << "==========" << std::endl;
+    std::cout << "==========" << '\n';
+    std::cout << '\n';
+    std::cout << '\n';
+    std::cout << "==========" << '\n';
+    std::cout << "Joint " << joint << '\n';
+    std::cout << "==========" << '\n';
+    std::cout << '\n';
+    std::cout << '\n';
+    std::cout << "==========" << '\n';
     for (size_t waypoint = 0; waypoint < static_cast<size_t>(output_trajectories.at(joint).positions.size()); ++waypoint)
     {
       std::cout << "Elapsed time: " << output_trajectories.at(joint).elapsed_times(waypoint)
                 << "  Position: " << output_trajectories.at(joint).positions(waypoint)
                 << "  Velocity: " << output_trajectories.at(joint).velocities(waypoint)
                 << "  Acceleration: " << output_trajectories.at(joint).accelerations(waypoint)
-                << "  Jerk: " << output_trajectories.at(joint).jerks(waypoint) << std::endl;
+                << "  Jerk: " << output_trajectories.at(joint).jerks(waypoint) << '\n';
     }
   }
-  std::cout << "============================================" << std::endl;
+  std::cout << "============================================" << '\n';
 
   return 0;
 }

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -201,7 +201,7 @@ ErrorCodeEnum TrajectoryGenerator::inputChecking(const std::vector<KinematicStat
   {
     // Print a warning but do not exit
     std::cout << "Capping desired duration at " << kMaxNumWaypointsFullTrajectory
-              << " waypoints to maintain determinism." << std::endl;
+              << " waypoints to maintain determinism." << '\n';
     desired_duration_ = kMaxNumWaypointsFullTrajectory * upsampled_timestep_;
   }
 
@@ -209,7 +209,7 @@ ErrorCodeEnum TrajectoryGenerator::inputChecking(const std::vector<KinematicStat
   {
     // Print a warning but do not exit
     std::cout << "Capping max duration at " << kMaxNumWaypointsFullTrajectory << " waypoints to maintain determinism."
-              << std::endl;
+              << '\n';
     max_duration_ = kMaxNumWaypointsFullTrajectory * upsampled_timestep_;
   }
 
@@ -279,7 +279,7 @@ void TrajectoryGenerator::saveTrajectoriesToFile(const std::vector<JointTrajecto
   // Warning if the folder does not exist
   if (!boost::filesystem::exists(base_filepath))
   {
-    std::cout << "Directory " << base_filepath << " does not exist. Cannot save results." << std::endl;
+    std::cout << "Directory " << base_filepath << " does not exist. Cannot save results." << '\n';
     return;
   }
 
@@ -300,7 +300,7 @@ void TrajectoryGenerator::saveTrajectoriesToFile(const std::vector<JointTrajecto
                   << output_trajectories.at(joint).positions(waypoint) << " "
                   << output_trajectories.at(joint).velocities(waypoint) << " "
                   << output_trajectories.at(joint).accelerations(waypoint) << " "
-                  << output_trajectories.at(joint).jerks(waypoint) << std::endl;
+                  << output_trajectories.at(joint).jerks(waypoint) << '\n';
     }
     output_file.clear();
     output_file.close();

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -190,7 +190,7 @@ void TrajectoryGenerator::downSample(Eigen::VectorXd* time_vector, Eigen::Vector
   *position_vector = new_positions;
   *velocity_vector = new_velocities;
   *acceleration_vector = new_accelerations;
-  *jerk_vector = DiscreteDifferentiation(new_accelerations, desired_timestep_, 0);
+  *jerk_vector = discreteDifferentiation(new_accelerations, desired_timestep_, 0);
 }
 
 ErrorCodeEnum TrajectoryGenerator::inputChecking(const std::vector<KinematicState>& current_joint_states,
@@ -378,11 +378,11 @@ ErrorCodeEnum TrajectoryGenerator::synchronizeTrajComponents(std::vector<JointTr
     {
       output_trajectories->at(joint) = single_joint_generators_[joint].getTrajectory();
 
-      ClipEigenVector(&output_trajectories->at(joint).positions, shortest_num_waypoints);
-      ClipEigenVector(&output_trajectories->at(joint).velocities, shortest_num_waypoints);
-      ClipEigenVector(&output_trajectories->at(joint).accelerations, shortest_num_waypoints);
-      ClipEigenVector(&output_trajectories->at(joint).jerks, shortest_num_waypoints);
-      ClipEigenVector(&output_trajectories->at(joint).elapsed_times, shortest_num_waypoints);
+      clipEigenVector(&output_trajectories->at(joint).positions, shortest_num_waypoints);
+      clipEigenVector(&output_trajectories->at(joint).velocities, shortest_num_waypoints);
+      clipEigenVector(&output_trajectories->at(joint).accelerations, shortest_num_waypoints);
+      clipEigenVector(&output_trajectories->at(joint).jerks, shortest_num_waypoints);
+      clipEigenVector(&output_trajectories->at(joint).elapsed_times, shortest_num_waypoints);
     }
   }
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -44,7 +44,7 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, dou
       timestep;
 
   return derivative;
-};
+}
 
 Eigen::VectorXd Normalize(const Eigen::VectorXd& x)
 {
@@ -115,7 +115,7 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
   }
 
   return derivative;
-};
+}
 
 void PrintJointTrajectory(const std::size_t joint, const std::vector<JointTrajectory>& output_trajectories,
                           const double desired_duration)

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -120,19 +120,19 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
 void PrintJointTrajectory(const std::size_t joint, const std::vector<JointTrajectory>& output_trajectories,
                           const double desired_duration)
 {
-  std::cout << "==========" << std::endl;
-  std::cout << std::endl;
-  std::cout << std::endl;
-  std::cout << "==========" << std::endl;
-  std::cout << "Joint " << joint << std::endl;
-  std::cout << "==========" << std::endl;
-  std::cout << "  Num waypts: " << output_trajectories.at(joint).positions.size() << std::endl;
-  std::cout << "  Desired duration: " << desired_duration << std::endl;
+  std::cout << "==========" << '\n';
+  std::cout << '\n';
+  std::cout << '\n';
+  std::cout << "==========" << '\n';
+  std::cout << "Joint " << joint << '\n';
+  std::cout << "==========" << '\n';
+  std::cout << "  Num waypts: " << output_trajectories.at(joint).positions.size() << '\n';
+  std::cout << "  Desired duration: " << desired_duration << '\n';
   std::cout << "Timestep: " << output_trajectories.at(joint).elapsed_times[1]
             << "  Initial position: " << output_trajectories.at(joint).positions[0]
             << "  Initial velocity: " << output_trajectories.at(joint).velocities[0]
             << "  Initial acceleration: " << output_trajectories.at(joint).accelerations[0]
-            << "  Initial jerk: " << output_trajectories.at(joint).jerks[0] << std::endl;
+            << "  Initial jerk: " << output_trajectories.at(joint).jerks[0] << '\n';
   std::cout << "  Final position: "
             << output_trajectories.at(joint).positions[output_trajectories.at(joint).positions.size() - 1]
             << "  Final velocity: "
@@ -140,7 +140,7 @@ void PrintJointTrajectory(const std::size_t joint, const std::vector<JointTrajec
             << "  Final acceleration: "
             << output_trajectories.at(joint).accelerations[output_trajectories.at(joint).positions.size() - 1]
             << "  Final jerk: "
-            << output_trajectories.at(joint).jerks[output_trajectories.at(joint).positions.size() - 1] << std::endl;
+            << output_trajectories.at(joint).jerks[output_trajectories.at(joint).positions.size() - 1] << '\n';
 }
 
 void ClipEigenVector(Eigen::VectorXd* vector, size_t new_num_waypoints)

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -100,7 +100,7 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
 
   // Filter from front to back
   filter.reset(derivative(0));
-  for (long unsigned int point = 1; point < derivative.size(); ++point)
+  for (long int point = 1; point < derivative.size(); ++point)
   {
     // Lowpass filter the position command
     derivative(point) = filter.filter(derivative(point));

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -31,7 +31,7 @@
 
 namespace trackjoint
 {
-Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, double timestep, const double first_element)
+Eigen::VectorXd discreteDifferentiation(const Eigen::VectorXd& input_vector, double timestep, const double first_element)
 {
   // derivative = (difference between adjacent elements) / timestep
   Eigen::VectorXd input_shifted_right(input_vector.size());
@@ -46,7 +46,7 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, dou
   return derivative;
 }
 
-Eigen::VectorXd Normalize(const Eigen::VectorXd& x)
+Eigen::VectorXd normalize(const Eigen::VectorXd& x)
 {
   const double min = x.minCoeff();
   const double max = x.maxCoeff();
@@ -59,7 +59,7 @@ Eigen::VectorXd Normalize(const Eigen::VectorXd& x)
 
 // TODO(andyz): This is horribly inefficient. Maybe it would be best to store everything as splines always.
 // Also (maybe) to store everything in one large matrix with columns for each derivative.
-Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element)
+Eigen::VectorXd splineDifferentiation(const Eigen::VectorXd& input_vector, double timestep, double first_element)
 {
   // Fit a spline through the input vector
   size_t num_points = input_vector.size();
@@ -71,7 +71,7 @@ Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, doubl
     times(i) = times(i - 1) + timestep;
   }
 
-  const auto knots = Normalize(times);
+  const auto knots = normalize(times);
   const auto fit = SplineFitting1D::Interpolate(input_row, 3, knots);
   double scale = 1 / (times.maxCoeff() - times.minCoeff());
 
@@ -90,10 +90,10 @@ Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, doubl
   return derivative.transpose();
 }
 
-Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
+Eigen::VectorXd discreteDifferentiationWithFiltering(const Eigen::VectorXd& input_vector, const double timestep,
                                                      const double first_element, const double filter_coefficient)
 {
-  Eigen::VectorXd derivative = DiscreteDifferentiation(input_vector, timestep, first_element);
+  Eigen::VectorXd derivative = discreteDifferentiation(input_vector, timestep, first_element);
 
   // Apply a low-pass filter
   ButterworthFilter filter(filter_coefficient);
@@ -117,7 +117,7 @@ Eigen::VectorXd DiscreteDifferentiationWithFiltering(const Eigen::VectorXd& inpu
   return derivative;
 }
 
-void PrintJointTrajectory(const std::size_t joint, const std::vector<JointTrajectory>& output_trajectories,
+void printJointTrajectory(const std::size_t joint, const std::vector<JointTrajectory>& output_trajectories,
                           const double desired_duration)
 {
   std::cout << "==========" << '\n';
@@ -143,13 +143,13 @@ void PrintJointTrajectory(const std::size_t joint, const std::vector<JointTrajec
             << output_trajectories.at(joint).jerks[output_trajectories.at(joint).positions.size() - 1] << '\n';
 }
 
-void ClipEigenVector(Eigen::VectorXd* vector, size_t new_num_waypoints)
+void clipEigenVector(Eigen::VectorXd* vector, size_t new_num_waypoints)
 {
   Eigen::VectorXd new_vector = vector->head(new_num_waypoints);
   *vector = new_vector;
 }
 
-bool VerifyVectorWithinBounds(double low_limit, double high_limit, Eigen::VectorXd& vector)
+bool verifyVectorWithinBounds(double low_limit, double high_limit, Eigen::VectorXd& vector)
 {
   if (high_limit < low_limit)
     return false;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -46,7 +46,7 @@ Eigen::VectorXd DiscreteDifferentiation(const Eigen::VectorXd& input_vector, dou
   return derivative;
 };
 
-Eigen::VectorXd normalize(const Eigen::VectorXd& x)
+Eigen::VectorXd Normalize(const Eigen::VectorXd& x)
 {
   const double min = x.minCoeff();
   const double max = x.maxCoeff();
@@ -71,7 +71,7 @@ Eigen::VectorXd SplineDifferentiation(const Eigen::VectorXd& input_vector, doubl
     times(i) = times(i - 1) + timestep;
   }
 
-  const auto knots = normalize(times);
+  const auto knots = Normalize(times);
   const auto fit = SplineFitting1D::Interpolate(input_row, 3, knots);
   double scale = 1 / (times.maxCoeff() - times.minCoeff());
 

--- a/test/trajectory_generation_test.cpp
+++ b/test/trajectory_generation_test.cpp
@@ -153,7 +153,7 @@ protected:
                     << output_trajectories_.at(joint).positions(waypoint) << " "
                     << output_trajectories_.at(joint).velocities(waypoint) << " "
                     << output_trajectories_.at(joint).accelerations(waypoint) << " "
-                    << output_trajectories_.at(joint).jerks(waypoint) << std::endl;
+                    << output_trajectories_.at(joint).jerks(waypoint) << '\n';
       }
       output_file.clear();
       output_file.close();
@@ -320,7 +320,7 @@ TEST_F(TrajectoryGenerationTest, DetectNoReset)
   EXPECT_EQ(error_code, ErrorCodeEnum::OBJECT_NOT_RESET);
 
   // Ensure OBJECT_NOT_RESET can be converted to string
-  std::cout << "Error: " << trackjoint::ERROR_CODE_MAP.at(error_code) << std::endl;
+  std::cout << "Error: " << trackjoint::ERROR_CODE_MAP.at(error_code) << '\n';
 
   // TearDown() should skip post-test checks
   skip_teardown_checks_ = true;

--- a/test/trajectory_generation_test.cpp
+++ b/test/trajectory_generation_test.cpp
@@ -133,7 +133,7 @@ protected:
       min_pos = std::min(potential_min, potential_min_2);
       max_pos = std::max(potential_max, potential_max_2);
 
-      EXPECT_TRUE(VerifyVectorWithinBounds(min_pos, max_pos, output_trajectories_[i].positions));
+      EXPECT_TRUE(verifyVectorWithinBounds(min_pos, max_pos, output_trajectories_[i].positions));
     }
   }
 


### PR DESCRIPTION
Some changes to improve consistency and implement best practices:

- Const the print function in kinematic state as it doesn't modify the object
- Switch std::endl to '\n' to avoid excess flushing and improve performance
- Capitalize some function names for consistency
- Fix a warning about comparing a long unsigned int with a long int
- Remove inconsistent semicolons after function definitions