### PR TITLE
Add stdexcept to butterworth_filter

### DIFF
--- a/include/trackjoint/butterworth_filter.h
+++ b/include/trackjoint/butterworth_filter.h
@@ -35,6 +35,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <stdexcept>
 
 namespace trackjoint
 {

--- a/src/trajectory_generator.cpp
+++ b/src/trajectory_generator.cpp
@@ -47,7 +47,7 @@ TrajectoryGenerator::TrajectoryGenerator(uint num_dof, double timestep, double d
 {
   // Upsample if num. waypoints would be short. Helps with accuracy
   upsample();
-  size_t max_num_waypoints = static_cast<size_t>(std::ceil( max_duration / upsampled_timestep_ ));
+  size_t max_num_waypoints = static_cast<size_t>(std::ceil(max_duration / upsampled_timestep_));
 
   // Initialize a trajectory generator for each joint
   for (size_t joint = 0; joint < kNumDof; ++joint)


### PR DESCRIPTION
Without this, I get the following build error:

`error: ‘length_error’ is not a member of ‘std’`